### PR TITLE
Exhaust existing poll request (eg. timed out queues)

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -69,8 +69,8 @@ func main() {
 			fqdn, _ := ioutil.ReadAll(r.Body)
 			request, err := coordinator.WaitForScrapeInstruction(strings.TrimSpace(string(fqdn)))
 			if err != nil {
-				level.Info(logger).Log("msg", "Request is expired")
-				http.Error(w, "request is expired", 408)
+				level.Info(logger).Log("msg", "Error WaitForScrapeInstruction:", "err", err)
+				http.Error(w, fmt.Sprintf("Error WaitForScrapeInstruction: %s", err.Error()), 408)
 				return
 			}
 			request.WriteProxy(w) // Send full request as the body of the response.

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -67,7 +67,12 @@ func main() {
 		// Client registering and asking for scrapes.
 		if r.URL.Path == "/poll" {
 			fqdn, _ := ioutil.ReadAll(r.Body)
-			request, _ := coordinator.WaitForScrapeInstruction(strings.TrimSpace(string(fqdn)))
+			request, err := coordinator.WaitForScrapeInstruction(strings.TrimSpace(string(fqdn)))
+			if err != nil {
+				level.Info(logger).Log("msg", "Request is expired")
+				http.Error(w, "request is expired", 408)
+				return
+			}
 			request.WriteProxy(w) // Send full request as the body of the response.
 			level.Info(logger).Log("msg", "Responded to /poll", "url", request.URL.String(), "scrape_id", request.Header.Get("Id"))
 			return


### PR DESCRIPTION
There is a problem around client timeouts. This patch fixes unnecessary queue accumulation.

(Timeouts may be caused by the front-end (authentication) http server)