### PR TITLE
Always add trailing '/' to proxyURL

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -154,6 +154,8 @@ func main() {
 		level.Error(coordinator.logger).Log("msg", "-proxy-url flag must be specified.")
 		os.Exit(1)
 	}
+	// Make sure proxyURL ends with a single '/'
+	*proxyURL = strings.TrimRight(*proxyURL, "/") + "/"
 	level.Info(coordinator.logger).Log("msg", "URL and FQDN info", "proxy_url", *proxyURL, "Using FQDN of", *myFqdn)
 
 	tlsConfig := &tls.Config{}


### PR DESCRIPTION
TL;DR This small patch allows the `client` to contact a remote `proxy` service which runs behind a URL which is not necessarily bound to `/`.

Background:
I've been trying to run PushProx `proxy` behind a reverse proxy.
The reverse proxy was listening on the URL `http://servername/pushprox/`
Once a connection comes in to the reverse proxy, the `servername` is replaced to the internal host and the `/pushprox` is stripped from the URL.
This configuration works just fine from the `proxy` process side. However, the `client` couldn't properly contact the serve because the `/pushprox/` was stripped from the final URL.

The reverse-proxy configuration is based on nginx. This is the configuration block used:
```
        location /promproxy/ {
                # All requests originated to the "/promproxy/" are relayed to the prometheus "proxy" service and "/promproxy/" is truncated from requested URL.
                proxy_pass http://172.17.0.1:8080/;
                # Force HTTP/1.1 so websocket will work (the connection will be kept alive).
                proxy_http_version 1.1;
                proxy_set_header Upgrade $http_upgrade;
        }
```