### PR TITLE
Fix logging of fqdn

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -156,7 +156,7 @@ func main() {
 	}
 	// Make sure proxyURL ends with a single '/'
 	*proxyURL = strings.TrimRight(*proxyURL, "/") + "/"
-	level.Info(coordinator.logger).Log("msg", "URL and FQDN info", "proxy_url", *proxyURL, "Using FQDN of", *myFqdn)
+	level.Info(coordinator.logger).Log("msg", "URL and FQDN info", "proxy_url", *proxyURL, "fqdn", *myFqdn)
 
 	tlsConfig := &tls.Config{}
 	if *tlsCert != "" {


### PR DESCRIPTION
The line was never displayed since the key contained spaces, hence the logger swallowed it