### PR TITLE
Get flags from environment

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -26,11 +26,11 @@ import (
 )
 
 var (
-	myFqdn     = kingpin.Flag("fqdn", "FQDN to register with").Default(fqdn.Get()).String()
-	proxyURL   = kingpin.Flag("proxy-url", "Push proxy to talk to.").Required().String()
-	caCertFile = kingpin.Flag("tls.cacert", "<file> CA certificate to verify peer against").String()
-	tlsCert    = kingpin.Flag("tls.cert", "<cert> Client certificate file").String()
-	tlsKey     = kingpin.Flag("tls.key", "<key> Private key file").String()
+	myFqdn     = kingpin.Flag("fqdn", "FQDN to register with").Envar("FQDN").Default(fqdn.Get()).String()
+	proxyURL   = kingpin.Flag("proxy-url", "Push proxy to talk to.").Envar("PROXY_URL").Required().String()
+	caCertFile = kingpin.Flag("tls.cacert", "<file> CA certificate to verify peer against").Envar("TLS_CACERT").String()
+	tlsCert    = kingpin.Flag("tls.cert", "<cert> Client certificate file").Envar("TLS_CERT").String()
+	tlsKey     = kingpin.Flag("tls.key", "<key> Private key file").Envar("TLS_KEY").String()
 )
 
 type Coordinator struct {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	listenAddress = kingpin.Flag("web.listen-address", "Address to listen on for proxy and client requests.").Default(":8080").String()
+	listenAddress = kingpin.Flag("web.listen-address", "Address to listen on for proxy and client requests.").Envar("WEB_LISTEN_ADDRESS").Default(":8080").String()
 )
 
 func copyHTTPResponse(resp *http.Response, w http.ResponseWriter) {


### PR DESCRIPTION
Instruct kingpin to try to get flags from environment variables for containerised usage.
Kinpin has a `DefaultEnvars` to automatically do this, but that would require more changes (e.g. creating an `kingpin.Application`) so I went for this approach.