### PR TITLE
Fix max-timeout bug

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -67,7 +67,8 @@ type Coordinator struct {
 
 func (c *Coordinator) doScrape(request *http.Request, client *http.Client) {
 	logger := log.With(c.logger, "scrape_id", request.Header.Get("id"))
-	ctx, _ := context.WithTimeout(request.Context(), util.GetScrapeTimeout(request.Header))
+	timeout, _ := util.GetTimeoutHeader(request.Header)
+	ctx, _ := context.WithTimeout(request.Context(), timeout)
 	request = request.WithContext(ctx)
 	// We cannot handle https requests at the proxy, as we would only
 	// see a CONNECT, so use a URL parameter to trigger it.

--- a/proxy/coordinator.go
+++ b/proxy/coordinator.go
@@ -13,8 +13,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	// "github.com/robustperception/pushprox/util"
-	"github.com/snarlysodboxer/PushProx/util"
+	"github.com/robustperception/pushprox/util"
 )
 
 var (

--- a/proxy/coordinator.go
+++ b/proxy/coordinator.go
@@ -13,7 +13,8 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/robustperception/pushprox/util"
+	// "github.com/robustperception/pushprox/util"
+	"github.com/snarlysodboxer/PushProx/util"
 )
 
 var (
@@ -90,7 +91,7 @@ func (c *Coordinator) DoScrape(ctx context.Context, r *http.Request) (*http.Resp
 	r.Header.Add("Id", id)
 	select {
 	case <-ctx.Done():
-		return nil, fmt.Errorf("Matching client not found for %q: %s", r.URL.String(), ctx.Err())
+		return nil, fmt.Errorf("Timeout reached for %q: %s", r.URL.String(), ctx.Err())
 	case c.getRequestChannel(r.URL.Hostname()) <- r:
 	}
 
@@ -140,7 +141,7 @@ func (c *Coordinator) WaitForScrapeInstruction(fqdn string) (*http.Request, erro
 func (c *Coordinator) ScrapeResult(r *http.Response) error {
 	id := r.Header.Get("Id")
 	level.Info(c.logger).Log("msg", "ScrapeResult", "scrape_id", id)
-	ctx, _ := context.WithTimeout(context.Background(), util.GetScrapeTimeout(r.Header))
+	ctx, _ := context.WithTimeout(context.Background(), util.GetScrapeTimeout(maxScrapeTimeout, defaultScrapeTimeout, r.Header))
 	// Don't expose internal headers.
 	r.Header.Del("Id")
 	r.Header.Del("X-Prometheus-Scrape-Timeout-Seconds")

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -21,11 +21,14 @@ import (
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/common/promlog/flag"
 
-	"github.com/robustperception/pushprox/util"
+	// "github.com/robustperception/pushprox/util"
+	"github.com/snarlysodboxer/PushProx/util"
 )
 
 var (
-	listenAddress = kingpin.Flag("web.listen-address", "Address to listen on for proxy and client requests.").Default(":8080").String()
+	listenAddress        = kingpin.Flag("web.listen-address", "Address to listen on for proxy and client requests.").Default(":8080").String()
+	maxScrapeTimeout     = kingpin.Flag("scrape.max-timeout", "Any scrape with a timeout higher than this will have to be clamped to this.").Default("5m").Duration()
+	defaultScrapeTimeout = kingpin.Flag("scrape.default-timeout", "If a scrape lacks a timeout, use this value.").Default("15s").Duration()
 )
 
 var (
@@ -141,7 +144,7 @@ func (h *httpHandler) handleListClients(w http.ResponseWriter, r *http.Request) 
 
 // handleProxy handles proxied scrapes from Prometheus.
 func (h *httpHandler) handleProxy(w http.ResponseWriter, r *http.Request) {
-	ctx, _ := context.WithTimeout(r.Context(), util.GetScrapeTimeout(r.Header))
+	ctx, _ := context.WithTimeout(r.Context(), util.GetScrapeTimeout(maxScrapeTimeout, defaultScrapeTimeout, r.Header))
 	request := r.WithContext(ctx)
 	request.RequestURI = ""
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -21,8 +21,7 @@ import (
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/common/promlog/flag"
 
-	// "github.com/robustperception/pushprox/util"
-	"github.com/snarlysodboxer/PushProx/util"
+	"github.com/robustperception/pushprox/util"
 )
 
 var (

--- a/util/proxy.go
+++ b/util/proxy.go
@@ -4,23 +4,25 @@ import (
 	"net/http"
 	"strconv"
 	"time"
-
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
-var (
-	maxScrapeTimeout     = kingpin.Flag("scrape.max-timeout", "Any scrape with a timeout higher than this will have to be clamped to this.").Default("5m").Duration()
-	defaultScrapeTimeout = kingpin.Flag("scrape.default-timeout", "If a scrape lacks a timeout, use this value.").Default("15s").Duration()
-)
-
-func GetScrapeTimeout(h http.Header) time.Duration {
+func GetScrapeTimeout(maxScrapeTimeout, defaultScrapeTimeout *time.Duration, h http.Header) time.Duration {
 	timeout := *defaultScrapeTimeout
-	timeoutSeconds, err := strconv.ParseFloat(h.Get("X-Prometheus-Scrape-Timeout-Seconds"), 64)
+	headerTimeout, err := GetHeaderTimeout(h)
 	if err == nil {
-		timeout = time.Duration(timeoutSeconds * 1e9)
+		timeout = headerTimeout
 	}
 	if timeout > *maxScrapeTimeout {
 		timeout = *maxScrapeTimeout
 	}
 	return timeout
+}
+
+func GetHeaderTimeout(h http.Header) (time.Duration, error) {
+	timeoutSeconds, err := strconv.ParseFloat(h.Get("X-Prometheus-Scrape-Timeout-Seconds"), 64)
+	if err != nil {
+		return time.Duration(0 * time.Second), err
+	}
+
+	return time.Duration(timeoutSeconds * 1e9), nil
 }

--- a/util/proxy_test.go
+++ b/util/proxy_test.go
@@ -1,0 +1,70 @@
+package util
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestGetScrapeTimeout(t *testing.T) {
+	// With header set
+	maxScrapeTimeout := time.Duration(5 * time.Minute)
+	defaultScrapeTimeout := time.Duration(10 * time.Second)
+	header := http.Header{"X-Prometheus-Scrape-Timeout-Seconds": []string{"5.0"}}
+	timeout := GetScrapeTimeout(&maxScrapeTimeout, &defaultScrapeTimeout, header)
+	if timeout != time.Duration(5*time.Second) {
+		t.Errorf("Expected 5s, got %s", timeout)
+	}
+
+	// With header unset
+	header = http.Header{}
+	timeout = GetScrapeTimeout(&maxScrapeTimeout, &defaultScrapeTimeout, header)
+	if timeout != time.Duration(10*time.Second) {
+		t.Errorf("Expected 10s, got %s", timeout)
+	}
+
+	// With header set empty
+	header = http.Header{"X-Prometheus-Scrape-Timeout-Seconds": []string{}}
+	timeout = GetScrapeTimeout(&maxScrapeTimeout, &defaultScrapeTimeout, header)
+	if timeout != time.Duration(10*time.Second) {
+		t.Errorf("Expected 10s, got %s", timeout)
+	}
+
+	// With header set higher than maxScrapeTimeout
+	header = http.Header{"X-Prometheus-Scrape-Timeout-Seconds": []string{"600.0"}}
+	timeout = GetScrapeTimeout(&maxScrapeTimeout, &defaultScrapeTimeout, header)
+	if timeout != time.Duration(5*time.Minute) {
+		t.Errorf("Expected 5m0s, got %s", timeout)
+	}
+
+	// With header set higher than defaultScrapeTimeout, lower than maxScrapeTimeout
+	header = http.Header{"X-Prometheus-Scrape-Timeout-Seconds": []string{"30.0"}}
+	defaultScrapeTimeout = time.Duration(10 * time.Second)
+	timeout = GetScrapeTimeout(&maxScrapeTimeout, &defaultScrapeTimeout, header)
+	if timeout != time.Duration(30*time.Second) {
+		t.Errorf("Expected 30s, got %s", timeout)
+	}
+}
+
+func TestGetHeaderTimeout(t *testing.T) {
+	// With header set
+	header := http.Header{"X-Prometheus-Scrape-Timeout-Seconds": []string{"5.0"}}
+	timeout, err := GetHeaderTimeout(header)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if timeout != time.Duration(5*time.Second) {
+		t.Errorf("Expected 5s, got %s", timeout)
+	}
+
+	// With header unset
+	header = http.Header{}
+	timeout, err = GetHeaderTimeout(header)
+	if err == nil {
+		t.Error("Expected error, got none")
+	}
+	if timeout != time.Duration(0*time.Second) {
+		t.Errorf("Expected 0s, got %s", timeout)
+	}
+
+}


### PR DESCRIPTION
The flag vars in [util/proxy.go](https://github.com/RobustPerception/PushProx/blob/master/util/proxy.go#L12) don't get parsed because it's a
separate package, and thus are set to zero values, causing an immediate "context
deadline exceeded". This patch puts them back in `proxy/proxy.go`, and
adds a couple of tests.