### PR TITLE
Allow override of metrics URL in client for security

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,8 @@ There is no authentication or authorisation included, a reverse proxy can be
 put in front though to add these.
 
 Running the client allows those with access to the proxy or the client to access
-all network services on the machine hosting the client.
+all network services on the machine hosting the client, unless you specify the
+`--override-url` setting.
+```
+./client --proxy-url=http://proxy:8080/ --override-url=http://client:9100/metrics
+```

--- a/client/client.go
+++ b/client/client.go
@@ -24,9 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/common/promlog/flag"
-	// TODO
-	// "github.com/robustperception/pushprox/util"
-	"github.com/snarlysodboxer/PushProx/util"
+	"github.com/robustperception/pushprox/util"
 )
 
 var (

--- a/client/client.go
+++ b/client/client.go
@@ -24,7 +24,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/common/promlog/flag"
-	"github.com/robustperception/pushprox/util"
+	// TODO
+	// "github.com/robustperception/pushprox/util"
+	"github.com/snarlysodboxer/PushProx/util"
 )
 
 var (
@@ -34,6 +36,7 @@ var (
 	tlsCert     = kingpin.Flag("tls.cert", "<cert> Client certificate file").String()
 	tlsKey      = kingpin.Flag("tls.key", "<key> Private key file").String()
 	metricsAddr = kingpin.Flag("metrics-addr", "Serve Prometheus metrics at this address").Default(":9369").String()
+	overrideURL = kingpin.Flag("override-url", "<URL> Force the URL to scrape").String()
 )
 
 var (
@@ -72,6 +75,16 @@ func (c *Coordinator) doScrape(request *http.Request, client *http.Client) {
 	// We cannot handle https requests at the proxy, as we would only
 	// see a CONNECT, so use a URL parameter to trigger it.
 	params := request.URL.Query()
+
+	// Force GET verb
+	request.Method = "GET"
+
+	// Override
+	if err := util.OverrideURLIfDesired(overrideURL, request); err != nil {
+		level.Error(logger).Log("msg", "Failed to parse overrideURL:", "err", err)
+		return
+	}
+
 	if params.Get("_scheme") == "https" {
 		request.URL.Scheme = "https"
 		params.Del("_scheme")

--- a/util/client.go
+++ b/util/client.go
@@ -1,0 +1,18 @@
+package util
+
+import (
+	"net/http"
+	"net/url"
+)
+
+func OverrideURLIfDesired(overrideURL *string, request *http.Request) error {
+	if *overrideURL != "" {
+		parsedURL, err := url.Parse(*overrideURL)
+		if err != nil {
+			return err
+		}
+		request.URL = parsedURL
+	}
+
+	return nil
+}

--- a/util/client_test.go
+++ b/util/client_test.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestOverrideURLIfDesired(t *testing.T) {
+	// With override
+	request := &http.Request{URL: &url.URL{Scheme: "http", Host: "wrong-service:9090", Path: "/v1/user/1"}}
+	overrideURL := "http://localhost:8080/metrics"
+	err := OverrideURLIfDesired(&overrideURL, request)
+	if err != nil {
+		t.Errorf("Expected no error, got one: %v", err)
+	}
+	if request.URL.String() != overrideURL {
+		t.Errorf("Expected %s, got %s", overrideURL, request.URL.String())
+	}
+
+	// Without override
+	request = &http.Request{URL: &url.URL{Scheme: "http", Host: "localhost:9090", Path: "/metrics"}}
+	overrideURL = ""
+	err = OverrideURLIfDesired(&overrideURL, request)
+	if err != nil {
+		t.Errorf("Expected no error, got one: %v", err)
+	}
+	nonOverride := "http://localhost:9090/metrics"
+	if request.URL.String() != nonOverride {
+		t.Errorf("Expected %s, got %s", nonOverride, request.URL.String())
+	}
+}


### PR DESCRIPTION
Some use cases require being able to protect against a bad actor on the proxy side. E.G. someone with access to the proxy could send valid yet malicious requests through the client, defeating the purpose of the network barrier.

For example, even with RBAC setup properly, running a Kubernetes Pod with a sidecar client container would allow access to the other services in the pod by a compromised prometheus environment. I think many people's security requirements won't allow that.

This patch adds a backwards compatible `--override-url` option to the client.