### PR TITLE
client: Use sane default values for the custom transport

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -227,7 +228,19 @@ func main() {
 		}()
 	}
 
-	transport := &http.Transport{TLSClientConfig: tlsConfig}
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig: tlsConfig,
+	}
 
 	for {
 		err := loop(coordinator, transport)


### PR DESCRIPTION
When setting up the custom transport for TLS support, the values for
timeouts, keepalive, and connection counts are all defaulting to zero
values. This can cause the client to not reconnect to a server that has
become unavailable.

Use the values of DefaultTransport in net/http to set up the custom
transport with appropriate settings.

Fixes #46.