### PR TITLE
Add dockerfile for proxy and client components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,26 @@
+FROM alpine:latest as certificates
+RUN apk update && apk add --no-cache ca-certificates && update-ca-certificates
+
 FROM golang:1.12 as builder
 
 RUN go get github.com/robustperception/pushprox/proxy
 WORKDIR $GOPATH/src/github.com/robustperception/pushprox/proxy
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build
 
+RUN go get github.com/robustperception/pushprox/client
+WORKDIR $GOPATH/src/github.com/robustperception/pushprox/client
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build
+
 
 FROM scratch
 
-COPY --from=builder /go/src/github.com/robustperception/pushprox/proxy /app
+# Copy certs from alpine as they don't exist from scratch
+COPY --from=certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
+# Copy client and proxy from builder
+COPY --from=builder /go/src/github.com/robustperception/pushprox/proxy /app
+COPY --from=builder /go/src/github.com/robustperception/pushprox/client /app
+
+# default startup is the proxy. 
+# Can be overwridden with the docker --entrypoint flag, or the command field in kubernetes container v1 API
 ENTRYPOINT ["/app/proxy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,5 @@ COPY --from=builder /go/src/github.com/robustperception/pushprox/proxy /app
 COPY --from=builder /go/src/github.com/robustperception/pushprox/client /app
 
 # default startup is the proxy. 
-# Can be overwridden with the docker --entrypoint flag, or the command field in kubernetes container v1 API
+# Can be overridden with the docker --entrypoint flag, or the command field in Kubernetes container v1 API
 ENTRYPOINT ["/app/proxy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
-FROM golang:latest as builder
+FROM golang:1.12 as builder
 
 RUN go get github.com/robustperception/pushprox/proxy
 WORKDIR $GOPATH/src/github.com/robustperception/pushprox/proxy
-RUN go build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build
 
 
 FROM scratch
 
-COPY --from=builder /go/src/github.com/robustperception/pushprox/proxy /
-WORKDIR /
-CMD ["./proxy"]
+COPY --from=builder /go/src/github.com/robustperception/pushprox/proxy /app
 
-
+ENTRYPOINT ["/app/proxy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,11 @@ RUN go get github.com/robustperception/pushprox/proxy
 WORKDIR $GOPATH/src/github.com/robustperception/pushprox/proxy
 RUN go build
 
-FROM golang:alpine
-COPY --from=builder /go/src/github.com/robustperception/pushprox/proxy /app/
-WORKDIR /app
 
+FROM scratch
+
+COPY --from=builder /go/src/github.com/robustperception/pushprox/proxy /
+WORKDIR /
 CMD ["./proxy"]
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:latest as builder
+
+RUN go get github.com/robustperception/pushprox/proxy
+WORKDIR $GOPATH/src/github.com/robustperception/pushprox/proxy
+RUN go build
+
+FROM golang:alpine
+COPY --from=builder /go/src/github.com/robustperception/pushprox/proxy /app/
+WORKDIR /app
+
+CMD ["./proxy"]
+
+


### PR DESCRIPTION
This PR adds a dockerfile to build a container with the proxy and the client components. 

Running the container defaults to the proxy as the entrypoint. This can be overridden with the docker `--entrypoint` flag, or the `command` field in [Kubernetes container v1 API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#container-v1-core).