### PR TITLE
Fix: Strict mode to enforce FQDN

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -221,11 +221,6 @@ func main() {
 	logger := promlog.New(&promlogConfig)
 	coordinator := Coordinator{logger: logger}
 
-	if *myFqdn == "" {
-		level.Error(coordinator.logger).Log("msg", "client fqdn cannot be empty")
-		os.Exit(1)
-	}
-
 	if *proxyURL == "" {
 		level.Error(coordinator.logger).Log("msg", "--proxy-url flag must be specified.")
 		os.Exit(1)

--- a/client/client.go
+++ b/client/client.go
@@ -221,7 +221,7 @@ func main() {
 	logger := promlog.New(&promlogConfig)
 	coordinator := Coordinator{logger: logger}
 
-	if myFqdn == nil || strings.TrimSpace(*myFqdn) == "" {
+	if *myFqdn == "" {
 		level.Error(coordinator.logger).Log("msg", "client fqdn cannot be empty")
 		os.Exit(1)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -104,12 +104,7 @@ func (c *Coordinator) doScrape(request *http.Request, client *http.Client) {
 		request.URL.RawQuery = params.Encode()
 	}
 
-	fqdnURL, err := url.Parse(*myFqdn)
-	if err != nil {
-		c.handleErr(request, client, err)
-		return
-	}
-	if request.URL.Hostname() != fqdnURL.Hostname() {
+	if request.URL.Hostname() != *myFqdn {
 		c.handleErr(request, client, errors.New("scrape target doesn't match client fqdn"))
 		return
 	}
@@ -225,6 +220,12 @@ func main() {
 	kingpin.Parse()
 	logger := promlog.New(&promlogConfig)
 	coordinator := Coordinator{logger: logger}
+
+	if myFqdn == nil || strings.TrimSpace(*myFqdn) == "" {
+		level.Error(coordinator.logger).Log("msg", "client fqdn cannot be empty")
+		os.Exit(1)
+	}
+
 	if *proxyURL == "" {
 		level.Error(coordinator.logger).Log("msg", "--proxy-url flag must be specified.")
 		os.Exit(1)


### PR DESCRIPTION
Go docs:
https://golang.org/pkg/net/url/#Parse
> Trying to parse a hostname and path without a scheme is invalid but may not necessarily return an error, due to parsing ambiguities.

```
fqdnURL, err := url.Parse(*myFqdn)
if err != nil {
    c.handleErr(request, client, err)
    return
}
```
Example:
myFqdn was set to `b607b847b180`, scheme is missing, but no error (as mentioned in the docs).

We don't need to treat myFqdn as URL since it is not an URL but rather FQDN (which is schemaless)

Fixes: https://github.com/RobustPerception/PushProx/issues/64