### PR TITLE
Bugfix/jitter

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -210,6 +210,7 @@ func (d *decorrelatedJitter) calc() {
 }
 
 func (d *decorrelatedJitter) sleep() {
+	d.calc()
 	time.Sleep(time.Duration(d.duration))
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -198,9 +198,8 @@ type decorrelatedJitter struct {
 func newJitter() decorrelatedJitter {
 	rand.Seed(time.Now().UnixNano())
 	return decorrelatedJitter{
-		duration: 1,
-		min:      1,
-		cap:      10,
+		min: 50 * time.Millisecond,
+		cap: 5 * time.Second,
 	}
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -203,7 +203,7 @@ func newJitter() decorrelatedJitter {
 	}
 }
 
-func (d *decorrelatedJitter) calc() {
+func (d *decorrelatedJitter) calc() time.Duration {
 	change := rand.Float64() * float64(d.duration*time.Duration(3)-d.min)
 	d.duration = d.min + time.Duration(change)
 	if d.duration > d.cap {
@@ -212,11 +212,11 @@ func (d *decorrelatedJitter) calc() {
 	if d.duration < d.min {
 		d.duration = d.min
 	}
+	return d.duration
 }
 
 func (d *decorrelatedJitter) sleep() {
-	d.calc()
-	time.Sleep(time.Duration(d.duration))
+	time.Sleep(d.calc())
 }
 
 func main() {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -11,9 +11,11 @@ import (
 
 func TestJitter(t *testing.T) {
 	jitter := newJitter()
-	jitter.calc()
-	if !(jitter.min <= jitter.duration || jitter.duration <= jitter.cap) {
-		t.Fatal("invalid jitter value: ", jitter.duration)
+	for i := 0; i < 100000; i++ {
+		jitter.calc()
+		if !(jitter.min <= jitter.duration || jitter.duration <= jitter.cap) {
+			t.Fatal("invalid jitter value: ", jitter.duration)
+		}
 	}
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -12,9 +12,9 @@ import (
 func TestJitter(t *testing.T) {
 	jitter := newJitter()
 	for i := 0; i < 100000; i++ {
-		jitter.calc()
-		if !(jitter.min <= jitter.duration || jitter.duration <= jitter.cap) {
-			t.Fatal("invalid jitter value: ", jitter.duration)
+		duration := jitter.calc()
+		if !(jitter.min <= duration || duration <= jitter.cap) {
+			t.Fatal("invalid jitter value: ", duration)
 		}
 	}
 }


### PR DESCRIPTION
I noticed that the jitter is essentially constant (the system I ran it spent the majority of its time just logging the error, with basically no sleep in between).

This patchset changes the default times to 50ms, 5s and allows it to be configured. It also changes the type of the fields of the `decorrelatedJitter` struct to be `time.Duration` to be easier to reason about.