### PR TITLE
Update Dockerfile for new build process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,18 +37,6 @@ jobs:
           name: Run everything and test that Prometheus can scrape node_exporter via pushprox
           command: ./end-to-end-test.sh
 
-  publish_release:
-    executor: golang
-
-    steps:
-    - prometheus/setup_build_environment
-    - run: promu crossbuild tarballs
-    - run: promu checksum .tarballs
-    - run: promu release .tarballs
-    - store_artifacts:
-        path: .tarballs
-        destination: releases
-
 workflows:
   version: 2
   stuff:
@@ -62,7 +50,15 @@ workflows:
         filters:
           tags:
             only: /.*/
-    - publish_release:
+    - prometheus/publish_master:
+        context: org-context
+        requires:
+        - test
+        - build
+        filters:
+          branches:
+            only: master
+    - prometheus/publish_release:
         context: org-context
         requires:
         - test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,15 @@
-FROM alpine:latest as certificates
-RUN apk update && apk add --no-cache ca-certificates && update-ca-certificates
+# Requires `promu crossbuild` artifacts.
+ARG ARCH="amd64"
+ARG OS="linux"
+FROM quay.io/prometheus/busybox-${OS}-${ARCH}:glibc
 
-FROM golang:1.12 as builder
+ARG ARCH="amd64"
+ARG OS="linux"
+COPY .build/${OS}-${ARCH}/pushprox-proxy /bin/pushprox-proxy
+COPY .build/${OS}-${ARCH}/pushprox-client /bin/pushprox-client
 
-RUN go get github.com/robustperception/pushprox/proxy
-WORKDIR $GOPATH/src/github.com/robustperception/pushprox/proxy
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build
-
-RUN go get github.com/robustperception/pushprox/client
-WORKDIR $GOPATH/src/github.com/robustperception/pushprox/client
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build
-
-
-FROM scratch
-
-# Copy certs from alpine as they don't exist from scratch
-COPY --from=certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-
-# Copy client and proxy from builder
-COPY --from=builder /go/src/github.com/robustperception/pushprox/proxy /app
-COPY --from=builder /go/src/github.com/robustperception/pushprox/client /app
-
-# default startup is the proxy.
-# Can be overridden with the docker --entrypoint flag, or the command field in Kubernetes container v1 API
-ENTRYPOINT ["/app/proxy"]
+# The default startup is the proxy.
+# This can be overridden with the docker --entrypoint flag or the command
+# field in Kubernetes container v1 API.
+USER       nobody
+ENTRYPOINT ["/app/pushprox-proxy"]


### PR DESCRIPTION
Update the Dockerfile based on the new build process. Use the crossbuild
style Dockerfile to allow for easier multi-arch Docker images.

Fixes: https://github.com/RobustPerception/PushProx/issues/73

Signed-off-by: Ben Kochie <superq@gmail.com>