### PR TITLE
Fixed app path in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM quay.io/prometheus/busybox-${OS}-${ARCH}:glibc
 
 ARG ARCH="amd64"
 ARG OS="linux"
-COPY .build/${OS}-${ARCH}/pushprox-proxy /bin/pushprox-proxy
-COPY .build/${OS}-${ARCH}/pushprox-client /bin/pushprox-client
+COPY .build/${OS}-${ARCH}/pushprox-proxy /app/pushprox-proxy
+COPY .build/${OS}-${ARCH}/pushprox-client /app/pushprox-client
 
 # The default startup is the proxy.
 # This can be overridden with the docker --entrypoint flag or the command


### PR DESCRIPTION
I built the docker image and tried to run in, but it failed because binaries were copied into /bin and entrypoint is set to /app.
I changed the `COPY` command to copy the binaries in the /app directory instead.